### PR TITLE
removed updateTwicEscortRequired logic

### DIFF
--- a/src/components/terminal-bookings/data-table.tsx
+++ b/src/components/terminal-bookings/data-table.tsx
@@ -24,7 +24,6 @@ import {
 export interface TerminalOperatorDataTableMeta {
   updateBooking: (id: string, status: string, reservationDate?: string, reservationTime?: string, twicEscortRequired?: boolean)  => Promise<boolean>;
   markBookingLate: (id: string, status: string) => Promise<boolean>;
-  updateTwicEscortRequired: (id: string, twicEscortRequired: boolean) => Promise<boolean>;
 }
 
 interface DataTableProps<TData, TValue> {

--- a/src/routes/reservation.tsx
+++ b/src/routes/reservation.tsx
@@ -656,31 +656,6 @@ async function updateBooking(id: string, status: string, reservationDate?: strin
        
 //Update TWIC Requirement
 
-async function updateTwicEscortRequired(id: string, twicEscortRequired: boolean): Promise<boolean> {
-  if (!navigator.onLine) {
-    console.error("No internet connection. Update not submitted. Please check your connection and try again.");
-    toast.error("No internet connection. Update not submitted. Please check your connection and try again.");
-    return false; // Explicitly return false when offline
-  }
-
-  try {
-    let updatePayload: any = { cargoUnitID: id, twicEscortRequired: twicEscortRequired };
-
-    const { data: updatedContainerStatus } = await client.models.Container.update(updatePayload);
-    
-    console.log("Updated TWIC escort requirement:", updatedContainerStatus);
-
-    // Refresh relevant data after successful update
-    await fetchterminal_operator_requested();
-    await fetchTerminalOperatorModified();
-
-    return true;
-  } catch (error) {
-    console.error("Error updating TWIC escort requirement:", error);
-    toast.error("Error updating TWIC escort requirement. Please try again.");
-    return false; // Explicitly return false when the update fails
-  }
-}
 
 const [BCOOngoingData, setBCOOngoingBookings] = useState<BCOOngoingBooking[]>([]);
 
@@ -741,10 +716,10 @@ useEffect(() => {
         </div>
         <div className="w-xl max-w-9/10">
         <TabsContent value="requested">
-          <TerminalBookingsTable data={terminalopBookingsupcoming} status="Requested" meta={{updateBooking, updateTwicEscortRequired}} />
+          <TerminalBookingsTable data={terminalopBookingsupcoming} status="Requested" meta={{updateBooking}} />
         </TabsContent>
         <TabsContent value="modification">
-          <TerminalBookingsTable data={terminalOpModifiedBookings} status="Modified" meta={{updateBooking, updateTwicEscortRequired}} />
+          <TerminalBookingsTable data={terminalOpModifiedBookings} status="Modified" meta={{updateBooking}} />
         </TabsContent>
         <TabsContent value="ongoing">
           <TerminalBookingsTable data={terminalopBookingongoing} status="Ongoing" meta={{updateBooking, markBookingLate}} />

--- a/src/routes/reservation.tsx
+++ b/src/routes/reservation.tsx
@@ -653,8 +653,6 @@ async function updateBooking(id: string, status: string, reservationDate?: strin
     return false; // Explicitly return false when the update fails
   }
 }
-       
-//Update TWIC Requirement
 
 
 const [BCOOngoingData, setBCOOngoingBookings] = useState<BCOOngoingBooking[]>([]);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR removes any updateTwicEscortRequired logic.
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
N/A
<!-- e.g. CAR-123 -->

## Motivation and Context
Reused logic from updateBooking, so updateTwicEscortRequired logic was no longer needed.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
